### PR TITLE
Upgrade rack dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.rbc
 .bundle
 .config
+.idea/
+.ruby-gemset
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/background_streamer.gemspec
+++ b/background_streamer.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", "~> 1.4"
+  spec.add_dependency "rack", ">= 1.4"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end

--- a/lib/background_streamer/version.rb
+++ b/lib/background_streamer/version.rb
@@ -1,3 +1,3 @@
 module BackgroundStreamer
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
@kapost/core Allows for more recent versions of rack that have addressed many issues.  Also bumps version to 0.0.4.
