### PR TITLE
Limit number of background streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ class BulkController < ApplicationController
 end
 ```
 
+### Configuration
+
+Background streamer provides several configuration options that your app can leverage.
+
+* `logger`: Define a custom logger. *(defaults to a `Logger.new(STDOUT)`)*
+* `max_threads`: Define the thread limit for number of background streams. *(defaults to 50)*
+* `on_worker_exit`: Define a handler for thread unload logic, useful for closing active database
+  connections and the like. *(defaults to `nil`)*
+
+```ruby
+BackgroundStreamer.configure do |config|
+  config.logger = Rails.logger
+
+  config.max_threads = 100
+
+  config.on_worker_exit = proc do
+    ActiveRecord::Base.connection.disconnect!
+  end
+end
+```
+
+### Error Handling
+
+It is possible for `BackgroundStreamer::Worker.perform_async` to raise an error if the `max_thread`
+limit is reached.  Your application should be prepared to handle
+`BackgroundStreamer::ThreadLimitExceeded`.
+
 ## Contributing
 
 1. Fork it

--- a/lib/background_streamer.rb
+++ b/lib/background_streamer.rb
@@ -15,8 +15,17 @@ module BackgroundStreamer
     def logger=(logger)
       @logger = logger
     end
+
+    def max_threads
+      @max_threads ||= 50
+    end
+
+    def max_threads=(val)
+      @max_threads = val
+    end
   end
 end
 
-require "background_streamer/version"
+require 'background_streamer/version'
+require 'background_streamer/errors'
 require 'background_streamer/worker'

--- a/lib/background_streamer/errors.rb
+++ b/lib/background_streamer/errors.rb
@@ -1,0 +1,4 @@
+module BackgroundStreamer
+  class Error < StandardError; end
+  class ThreadLimitExceeded < Error; end
+end

--- a/lib/background_streamer/worker.rb
+++ b/lib/background_streamer/worker.rb
@@ -13,13 +13,13 @@ module BackgroundStreamer
 
     class << self
       def perform_async(env, body, options = {})
-        env[RACK_HIJACK].call
-
         threads.keep_if(&:alive?)
 
         if threads.size >= BackgroundStreamer.max_threads
           raise ThreadLimitExceeded, "Thread limit of #{BackgroundStreamer.max_threads} exceeded"
         end
+
+        env[RACK_HIJACK].call
 
         threads << Thread.new do
           worker = new(env, body, options)

--- a/lib/background_streamer/worker.rb
+++ b/lib/background_streamer/worker.rb
@@ -12,15 +12,27 @@ module BackgroundStreamer
     attr_reader :options, :timeout, :request_id, :status, :headers, :io, :body
 
     class << self
-      def perform_async(env, body, options={})
+      def perform_async(env, body, options = {})
         env[RACK_HIJACK].call
 
-        Thread.new do 
+        threads.keep_if(&:alive?)
+
+        if threads.size >= BackgroundStreamer.max_threads
+          raise ThreadLimitExceeded, "Thread limit of #{BackgroundStreamer.max_threads} exceeded"
+        end
+
+        threads << Thread.new do
           worker = new(env, body, options)
           worker.perform
 
           BackgroundStreamer.on_worker_exit.call if BackgroundStreamer.on_worker_exit
         end
+      end
+
+      private
+
+      def threads
+        @threads ||= []
       end
     end
       


### PR DESCRIPTION
@icebreaker @brandonc This is an attempt to add some parity regarding maximum amount of processing with regards to [this comment](https://github.com/kapost/background_streamer/pull/2#discussion_r44175590) pertaining to DDOS-ing.  It defined a maximum number of threads that defaults to 50, matching the old SizedQueue config.
