### PR TITLE
always write headers on the main thread

### DIFF
--- a/lib/background_streamer/version.rb
+++ b/lib/background_streamer/version.rb
@@ -1,3 +1,3 @@
 module BackgroundStreamer
-  VERSION = "0.0.5".freeze
+  VERSION = "0.0.6".freeze
 end


### PR DESCRIPTION
@kapost/core We have to write "headers" on the "main thread", because otherwise there can be intermittent connection "closed" errors.
